### PR TITLE
Eventos e Redes Sociais

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ Segue abaixo a lista de capítulos cadastrados na plataforma Meetup, e links das
 - Lavras - [Meetup](https://www.meetup.com/rladies-lavras/)
 - Goiânia - [Meetup](https://www.meetup.com/rladies-goiania/),  [Site](https://www.rladiesgyn.com/), [Twitter](https://twitter.com/rladiesgyn), [Instagram](https://www.instagram.com/rladiesgyn), [Linkedin](https://www.linkedin.com/in/r-ladies-gyn-017898195/), [GitHub](https://github.com/R-LadiesGYN/README)
 - Recife - [Meetup](https://www.meetup.com/rladies-recife/), [Instagram](https://www.instagram.com/rladiesrecife)
-- Manaus - [Meetup](https://www.meetup.com/R-Ladies-Manaus/), [Twitter](https://twitter.com/r_manaus), [Facebook](https://www.facebook.com/rladiesmanaus)
+- Manaus - [Meetup](https://www.meetup.com/R-Ladies-Manaus/), [Twitter](https://twitter.com/r_manaus), [Facebook](https://www.facebook.com/rladiesmanaus), [Instagram] (https://www.instagram.com/manausrladies)
 - Vitória - [Meetup](https://www.meetup.com/rladies-vitoria/), [Twitter](https://twitter.com/rladiesvix), [Instagram](https://www.instagram.com/rladiesvix)
 - Ribeirão Preto - [Meetup](https://www.meetup.com/rladies-ribeirao-preto/)
 - Natal - [Meetup](https://www.meetup.com/rladies-natal/), [Twitter](https://twitter.com/RLadiesNatal), [Instagram](https://www.instagram.com/rladiesnatal/)
 - Fortaleza - [Meetup](https://www.meetup.com/rladies-fortaleza/), [Twitter](http://www.twitter.com/RLadiesFortal)
 - Curitiba - [Meetup](https://www.meetup.com/rladies-curitibaa/), [LinkedIn](https://www.linkedin.com/company/r-ladies-curitiba), [Instagram](https://www.instagram.com/rladiescuritiba)
+- Teresina - [Instagram] (https://www.instagram.com/rladiesthe), Youtube (https://www.youtube.com/channel/UCiEloyxyXZluv7p46DGCqQQ)
 
 
 
@@ -33,7 +34,6 @@ OBS: [Esse  dashboard](https://benubah.github.io/r-community-explorer/rladies.ht
 |19/09/2020| Belo Horizonte | Curso - Sweeve (R + Latex) | [Sympla](https://www.sympla.com.br/we-r-ladies---curso-de-sweeve---r--latex__926022) |
 |30/09/2020| Rio de Janeiro + [LatinR](https://latin-r.com/pt) |  Manuscritos acadêmicos usando o pacote RMarkdown | Previsto - Em breve |
 |26/09/2020| Goiânia | RMarkdown | [Sympla](https://www.sympla.com.br/urlAlias/render?alias=cursosonline) |
-|06/10/2020| Rio de Janeiro | RMarkdown | Previsto - Em breve|
 |09/10/2020| Natal | R para Ciências Humanas (Dplyr + Ggplot2) | [Meetup](https://www.meetup.com/rladies-natal/events/273270143/)|
 |10/10/2020| São Paulo + [LatinR](https://latin-r.com/pt) |  Apresentações com pacote xaringan | Previsto - Em breve |
 |10/10/2020| Belo Horizonte | Dados da Saúde Aplicados ao R | Previsto - Em breve |

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Segue abaixo a lista de capítulos cadastrados na plataforma Meetup, e links das
 - Lavras - [Meetup](https://www.meetup.com/rladies-lavras/)
 - Goiânia - [Meetup](https://www.meetup.com/rladies-goiania/),  [Site](https://www.rladiesgyn.com/), [Twitter](https://twitter.com/rladiesgyn), [Instagram](https://www.instagram.com/rladiesgyn), [Linkedin](https://www.linkedin.com/in/r-ladies-gyn-017898195/), [GitHub](https://github.com/R-LadiesGYN/README)
 - Recife - [Meetup](https://www.meetup.com/rladies-recife/), [Instagram](https://www.instagram.com/rladiesrecife)
-- Manaus - [Meetup](https://www.meetup.com/R-Ladies-Manaus/), [Twitter](https://twitter.com/r_manaus), [Facebook](https://www.facebook.com/rladiesmanaus), [Instagram] (https://www.instagram.com/manausrladies)
+- Manaus - [Meetup](https://www.meetup.com/R-Ladies-Manaus/), [Twitter](https://twitter.com/r_manaus), [Facebook](https://www.facebook.com/rladiesmanaus), [Instagram](https://www.instagram.com/manausrladies)
 - Vitória - [Meetup](https://www.meetup.com/rladies-vitoria/), [Twitter](https://twitter.com/rladiesvix), [Instagram](https://www.instagram.com/rladiesvix)
 - Ribeirão Preto - [Meetup](https://www.meetup.com/rladies-ribeirao-preto/)
 - Natal - [Meetup](https://www.meetup.com/rladies-natal/), [Twitter](https://twitter.com/RLadiesNatal), [Instagram](https://www.instagram.com/rladiesnatal/)
 - Fortaleza - [Meetup](https://www.meetup.com/rladies-fortaleza/), [Twitter](http://www.twitter.com/RLadiesFortal)
 - Curitiba - [Meetup](https://www.meetup.com/rladies-curitibaa/), [LinkedIn](https://www.linkedin.com/company/r-ladies-curitiba), [Instagram](https://www.instagram.com/rladiescuritiba)
-- Teresina - [Instagram] (https://www.instagram.com/rladiesthe), Youtube (https://www.youtube.com/channel/UCiEloyxyXZluv7p46DGCqQQ)
+- Teresina - [Instagram](https://www.instagram.com/rladiesthe), [Youtube](https://www.youtube.com/channel/UCiEloyxyXZluv7p46DGCqQQ)
 
 
 


### PR DESCRIPTION
Inclusão das redes sociais R Ladies Teresina, e edição.
Inclusão do instagram R Ladies Manaus
Exclusão de evento não realizado R Ladies Rio, sem previsão para nova data.